### PR TITLE
Upgraded eslint-config-standard to v12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -592,9 +592,9 @@
       }
     },
     "eslint-config-standard": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
-      "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE="
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
+      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ=="
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "babel-eslint": "^8",
     "eslint": "^4",
     "eslint-config-airbnb": "^17",
-    "eslint-config-standard": "^10",
+    "eslint-config-standard": "^12",
     "eslint-plugin-babel": "x",
     "eslint-plugin-compat": "^2",
     "eslint-plugin-flowtype": "x",


### PR DESCRIPTION
This fix the deprecation warning ESLINT_LEGACY_OBJECT_REST_SPREAD.

See [issue #4](https://github.com/doasync/eslint-config-airbnb-standard/issues/4)